### PR TITLE
Sometimes does not detect the "a" in wall

### DIFF
--- a/COCBot/functions/Image Search/imglocCheckWall.au3
+++ b/COCBot/functions/Image Search/imglocCheckWall.au3
@@ -38,7 +38,7 @@ Func imglocCheckWall()
 				If _Sleep(500) Then Return
 				Local $aResult = BuildingInfo(245, 520 + $g_iBottomOffsetY) ; Get building name and level with OCR
 				If $aResult[0] = 2 Then ; We found a valid building name
-					If StringInStr($aResult[1], "wall") = True And Number($aResult[2]) = $levelWall Then ; we found a wall
+					If (StringInStr($aResult[1], "Wall") = True Or StringInStr($aResult[1], "W ll")) And Number($aResult[2]) = $levelWall Then ; we found a wall
 						Setlog("Position : " & $aCoord[0] & ", " & $aCoord[1] & " is a Wall Level: " & $levelWall & ".")
 						Return True
 					Else


### PR DESCRIPTION
Allow search for "w ll" to be valid also due to the OCR sometimes not recognizing the "a".